### PR TITLE
Redirect some dependencies to compile properly

### DIFF
--- a/src/components/chips.rs
+++ b/src/components/chips.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use leptos::prelude::*;
-use crate::components::ValueType;
+use crate::common::ValueType;
 
 /// # Chip Component
 /// 

--- a/src/pages/home_page.rs
+++ b/src/pages/home_page.rs
@@ -11,6 +11,7 @@ use crate::components::{
     ActionButton, CheckboxList, Loading, MultiEntry, OutlinedTextField, Panel, RadioList, Row,
     Select, ChipsList
 };
+use crate::input;
 use leptos::leptos_dom::logging::console_log;
 use leptos::prelude::*;
 use leptos_oidc::{Algorithm, AuthLoaded, AuthSignal, Authenticated};
@@ -294,6 +295,7 @@ pub fn HomePage() -> impl IntoView {
                                                         .collect()
                                                     disabled=elements_disabled
                                                     label="Required Community Involvement"
+                                                />
                                             </Row>
                                             <Row>
                                                 <MultiEntry


### PR DESCRIPTION
Some `use` statements were set up incorrectly due to an incorrect merge. This PR fixes these statements.