### PR TITLE
Add email filtering to OutlinedTextField

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,6 +2953,7 @@ dependencies = [
  "traits",
  "uuid",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ uuid = { version = "1.17.0", features = ["serde", "v4", "js"] }
 leptos_oidc = "0.9.0"
 base64 = "0.22.1"
 chrono = "0.4.42"
+web-sys = { version = "0.3", features = ["HtmlInputElement", "ValidityState" ] }
 
 macros = { path = "./macros" }
 traits = { path = "./traits" }

--- a/src/pages/home_page.rs
+++ b/src/pages/home_page.rs
@@ -233,6 +233,7 @@ pub fn HomePage() -> impl IntoView {
                                                 <OutlinedTextField
                                                     label="Contact Email:"
                                                     placeholder="student@region15.org"
+                                                    input_type="email"
                                                     disabled=elements_disabled
                                                     data_member="contact_email"
                                                     data_map=expandable_react.data

--- a/src/pages/loaner_page.rs
+++ b/src/pages/loaner_page.rs
@@ -248,6 +248,7 @@ pub fn LoanerBorrowForm() -> impl IntoView {
                 label="Region 15 Email:"
                 placeholder="example@region15.org"
                 disabled=elements_disabled
+                input_type="email"
                 data_member="email"
                 data_map=temp_reactive.data
             />


### PR DESCRIPTION
Adds the new "email" type to the outlined text field, which does some filtering and shows an error message when users input an incorrect value.

Error handling will need to be completely overhauled, across all components. While testing this, I found that any errors in input components do not affect the information that's given to the API during submit time, nor does it block submission at all. We also should be using the `Memo` and `Effect` more often here.