### PR TITLE
Create new email validation system

### DIFF
--- a/src/pages/home_page.rs
+++ b/src/pages/home_page.rs
@@ -285,7 +285,9 @@ pub fn HomePage() -> impl IntoView {
                                                         disabled=elements_disabled
                                                         data_member="contact_email"
                                                         data_map=form_data
-                                                        input_type=TextFieldType::Email
+                                                        input_type=TextFieldType::Email(
+                                                            vec!["fakeemail.org".to_string(), "gmail.com".to_string()]
+                                                        )
                                                         required=true
                                                     />
                                                 </Row>

--- a/src/pages/loaner_page.rs
+++ b/src/pages/loaner_page.rs
@@ -328,7 +328,7 @@ pub fn LoanerBorrowForm() -> impl IntoView {
                     disabled=elements_disabled
                     data_member="email"
                     data_map=data
-                    input_type=TextFieldType::Email
+                    input_type=TextFieldType::Email(vec!["region15.org".to_string()])
                     required=true
                 />
             </Row>

--- a/src/pages/provider_contact.rs
+++ b/src/pages/provider_contact.rs
@@ -178,7 +178,7 @@ pub fn ProviderContactPage() -> impl IntoView {
                                                         disabled=elements_disabled
                                                         data_member="contact_email"
                                                         data_map=contact_info
-                                                        input_type=TextFieldType::Email
+                                                        input_type=TextFieldType::Email(vec!["*".to_string()])
                                                         required=true
                                                     />
                                                 </Row>


### PR DESCRIPTION
As the title suggests, this PR creates a new email validation mechanic by editing the `TextFieldType::Email` enum, allowing programmers to add custom domains to the matching algorithm.

It also removes regex matching – not only was this expensive, but it was also far too challenging to transform our standard `String` emails into a regex pattern. Overall, it was not worth it, and the new version will work using pure Rust functions.