### PR TITLE
Show error toasts on failed submissions

### DIFF
--- a/src/pages/provider_contact.rs
+++ b/src/pages/provider_contact.rs
@@ -121,17 +121,23 @@ pub fn ProviderContactPage() -> impl IntoView {
 
     let mut toasts_context = expect_context::<ToastContext>();
     Effect::new(move || {
-        submit_action.value().get().is_some()
-            .then(|| {
-                toasts_context.toast(
-                    Toast::new()
-                        .id(uuid::Uuid::new_v4())
-                        .header("Submission Successful")
-                        .msg("You can go back or continue editing your responses.")
-                );
-                
-                submit_action.clear();
-            });
+        match submit_action.value().get() {
+            Some(Ok(_)) => toasts_context.toast(
+                Toast::new()
+                    .id(uuid::Uuid::new_v4())
+                    .header("Submission Successful")
+                    .msg("You can go back or continue editing your responses.")
+            ),
+            Some(Err(err)) => toasts_context.toast(
+                Toast::new()
+                    .id(uuid::Uuid::new_v4())
+                    .header("Submission Failed")
+                    .msg(err.to_string())
+            ),
+            _ => {}
+        }
+        
+        submit_action.clear();
     });
     
     // Display contact form.

--- a/src/pages/scholarship_info.rs
+++ b/src/pages/scholarship_info.rs
@@ -483,17 +483,23 @@ fn ScholarshipForm(
     };
     
     Effect::new(move || {
-        submit_action.value().get().is_some()
-            .then(|| {
-                log!("Displaying toasts!");
-                toasts.toast(
-                    Toast::new()
-                        .id(uuid::Uuid::new_v4())
-                        .msg("Succesfully submitted.")
-                );
-                
-                submit_action.clear();
-            });
+        match submit_action.value().get() {
+            Some(Ok(_)) => toasts.toast(
+                Toast::new()
+                    .id(uuid::Uuid::new_v4())
+                    .header("Submission Successful")
+                    .msg("You can go back or continue editing your responses.")
+            ),
+            Some(Err(err)) => toasts.toast(
+                Toast::new()
+                    .id(uuid::Uuid::new_v4())
+                    .header("Submission Failed")
+                    .msg(err.to_string())
+            ),
+            _ => {}
+        }
+
+        submit_action.clear();
     });
 
     let create_comps = ServerAction::<CreateTestComparisons>::new();


### PR DESCRIPTION
Instead of showing a successful submission toast every time the user clicks the submit button, we now check if there was an error and display that error. This does not create a new appearance for the toasts, but perhaps that would be a good thing to add in the future.