### PR TITLE
Check requirement return value on Ok variant

### DIFF
--- a/src/pages/student/eligibility_page.rs
+++ b/src/pages/student/eligibility_page.rs
@@ -117,11 +117,15 @@ pub fn StudentEligibilityPage() -> impl IntoView {
                                                             .compare(&student_info);
 
                                                         match result.as_ref() {
-                                                            Ok(_) => debug_log!("Requirement with id {} success", requirement.id),
-                                                            Err(e) => debug_error!("Requirement with id {} failed: {}", requirement.id, e)
-                                                        };
-
-                                                        result.is_ok()
+                                                            Ok(status) => {
+                                                                debug_log!("Requirement with id {} is Ok({})", requirement.id, status);
+                                                                status.clone()
+                                                            },
+                                                            Err(e) => {
+                                                                debug_error!("Requirement with id {} failed: {}", requirement.id, e);
+                                                                false
+                                                            }
+                                                        }
                                                     },
                                                 )
                                         }


### PR DESCRIPTION
This code was previously skipping the actual value returned from the comparisons API, and was assuming that an `Ok` value was always true. This is not in fact true, and this is now checked properly.