### PR TITLE
Insert trailing commas after lists of strings

### DIFF
--- a/src/pages/api/students.rs
+++ b/src/pages/api/students.rs
@@ -554,7 +554,8 @@ pub async fn get_student_pdf(student_id: String) -> Result<(String, Vec<u8>), Se
         .replace("[", "(")
         .replace("]", ")")
         // Ensures trailing commas for lists of dictionaries
-        .replace("))", "),)");
+        .replace("))", "),)")
+        .replace("\")", "\",)");
 
     debug_log!("New string: {}", typst_string);
 


### PR DESCRIPTION
This fix is due to the fact that a list containing a single string was parsed incorrectly. For example, `("value")` was parsed as a single string, while `("v1", "v2")` was parsed as a list. This was causing errors with the `#string.join()` function.